### PR TITLE
Enable multiple tours on the same URL & multi URL tours

### DIFF
--- a/classes/manager.php
+++ b/classes/manager.php
@@ -531,8 +531,11 @@ class manager {
           ORDER BY sortorder ASC
 EOF;
 
+        $localurl = $pageurl->out_as_local_url();
+        $usertour = optional_param('usertour', '', PARAM_ALPHANUMEXT);
+        $localurl .= '&amp;usertour='.$usertour;
         $tours = $DB->get_records_sql($sql, array(
-            $pageurl->out_as_local_url(),
+            $localurl,
         ));
 
         foreach ($tours as $record) {


### PR DESCRIPTION
As I am adding to any page URL the param: &usertour=forum-page1 (and/or &usertour=forum-page2 , &usertour=assign-page1 ... )

I use this "hack" to have single Moodle course with multiple page tours initiated from the same course front page, and also have those tours span across several inner Moodle pages. "linking" several "tours" into a single multi-tour. any by this, getting a single teacher training course.

Please review and see if you can integrate it into the plugin.
Nadav :-)